### PR TITLE
wechat: strip MDX comments, append References section

### DIFF
--- a/scripts/wechat.js
+++ b/scripts/wechat.js
@@ -425,8 +425,10 @@ const processArticles = async () => {
     processedContent = processedContent.replace(/^import React from 'react';\s*\n/gm, '');
     processedContent = processedContent.replace(/^export const (?:C|ProtocolStack|AutomationSpectrum|ToolEcosystem)\b[\s\S]*?^};\s*\n/gm, '');
 
-    // Remove truncate markers
-    processedContent = processedContent.replace(/\{\/\*\s*truncate\s*\*\/\}/g, '');
+    // Remove truncate markers and any other MDX/JSX comments. WeChat copy-paste
+    // surfaces these literally if they survive — `{/* ... */}` is treated as
+    // text once the file leaves the MDX renderer.
+    processedContent = processedContent.replace(/\{\/\*[\s\S]*?\*\/\}/g, '');
     
     // Convert admonitions
     processedContent = processedContent.replace(
@@ -455,12 +457,39 @@ const processArticles = async () => {
       (match, alt, imgPath) => `![${alt}](${BASE_URL}/img/${imgPath})`
     );
     
+    // Build a References section from all inline links in the body. WeChat
+    // 公众号 renders inline links inconsistently (and strips most external
+    // ones for unverified accounts), so a numbered list at the end with the
+    // URL printed on its own line lets readers see and copy every source.
+    const refs = [];
+    const seenUrls = new Set();
+    // URL portion allows one level of balanced parens so Wikipedia-style URLs
+    // like https://en.wikipedia.org/wiki/Variety_(cybernetics) are captured
+    // intact rather than truncated at the first inner `)`.
+    const linkPattern = /(^|[^!])\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)/g;
+    let linkMatch;
+    while ((linkMatch = linkPattern.exec(processedContent)) !== null) {
+      // Strip markdown emphasis (*italic*, **bold**, `code`) from the label so
+      // reference entries read as plain prose, not as raw markdown.
+      const text = linkMatch[2].trim().replace(/[\*_`]+/g, '').trim();
+      const url = linkMatch[3].trim();
+      // Skip anchor-only links and duplicates
+      if (!url || url.startsWith('#') || seenUrls.has(url)) continue;
+      seenUrls.add(url);
+      refs.push({ text, url });
+    }
+    if (refs.length > 0) {
+      const refHeader = article.locale === 'zh' ? '\n\n## 参考资料\n\n' : '\n\n## References\n\n';
+      const refList = refs.map((r, i) => `${i + 1}. ${r.text}\n   ${r.url}`).join('\n\n');
+      processedContent += refHeader + refList;
+    }
+
     // Add footer
     const postUrl = `${baseUrl}/blog/${article.slug}`;
     const footer = article.locale === 'zh'
       ? `\n\n---\n\n📝 **本文同步发布于我的个人技术博客** [marvinzhang.dev](${postUrl})\n\n🔗 **完整文章链接：** ${postUrl}\n\n💬 **欢迎访问我的博客了解更多技术文章！**`
       : `\n\n---\n\n📝 **Originally published on my personal blog** [marvinzhang.dev](${postUrl})\n\n🔗 **Full article link:** ${postUrl}\n\n💬 **Visit my blog for more tech articles!**`;
-    
+
     processedContent += footer;
     
     // Determine output path: spec folder if exists, otherwise .temp/wechat

--- a/static/wechat/vsm-cybernetics-system-organization.html
+++ b/static/wechat/vsm-cybernetics-system-organization.html
@@ -1,6 +1,4 @@
-<section style="font-family:Optima,PingFangSC-light,PingFangTC-light,"PingFang SC","Hiragino Sans GB","Source Han Sans CN","Source Han Sans SC",serif;font-size:16px;line-height:1.5em;color:#000;word-break:break-word;overflow-wrap:break-word;text-align:left;padding:0 10px;"><p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">{/* 中文译稿，逐节翻译。每节英文确认后立即翻译同一节。 <em style="font-style:italic;">/}
-{/</em> 文件名日期（2026-05-12）与前置数据日期保持一致。 */}</p>
-<p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">一个八人的工程师团队，把 <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/ai-agents-engineering">AI 编程智能体（AI Coding Agents）</a>接进了自己的开发流水线。智能体从队列顶端取走 JIRA 工单，提交合并请求的速度超过人工评审的速度。半年下来，仪表盘上的数字相当好看：测试覆盖率 84%，每个改动接口的 p99 延迟稳定在 100 毫秒以内，自从智能体上线后合并吞吐量翻了三倍。周五的复盘会越开越短，因为实在没什么可复盘的。</p>
+<section style="font-family:Optima,PingFangSC-light,PingFangTC-light,"PingFang SC","Hiragino Sans GB","Source Han Sans CN","Source Han Sans SC",serif;font-size:16px;line-height:1.5em;color:#000;word-break:break-word;overflow-wrap:break-word;text-align:left;padding:0 10px;"><p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">一个八人的工程师团队，把 <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/ai-agents-engineering">AI 编程智能体（AI Coding Agents）</a>接进了自己的开发流水线。智能体从队列顶端取走 JIRA 工单，提交合并请求的速度超过人工评审的速度。半年下来，仪表盘上的数字相当好看：测试覆盖率 84%，每个改动接口的 p99 延迟稳定在 100 毫秒以内，自从智能体上线后合并吞吐量翻了三倍。周五的复盘会越开越短，因为实在没什么可复盘的。</p>
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">直到有一天，竞争对手发布了一个新功能。算不上多巧妙的功能。竞争对手的用户已经在公开论坛上催了半年，团队自家用户在自家论坛上催了几乎一样长的时间。流水线里，没有一个人——也没有一个智能体——注意到这件事。竞争对手上线的消息周二午后落进 Slack 群，会议室一下子安静下来，因为所有人都在问同一个问题：我们这套系统里，到底哪一块本来应该接住这件事？</p>
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">诚实的回答是：没有这一块。不是有人忘了构建它，而是团队的架构语言里，根本没有一个词指向它。</p>
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">分层架构（Layered Architecture）、微服务（Microservices）、六边形架构（Hexagonal Architecture）、领域驱动设计（Domain-Driven Design，DDD）——这四种主导软件行业的架构语言，回答的都是同一个问题： <em style="font-style:italic;">代码该如何切分？</em> 它们没有一个能回答周二下午那个团队问的问题： <em style="font-style:italic;">这套系统，作为一个组织，靠什么活下去？</em> 这个问题一直有人在回答，只是答案不在架构图里，而在代码之外的人组织里：PM 和 Scrum Master 跑排期，SRE 与 QA 做审计，产品盯外部市场，高管定方向，On-Call 拉警报。架构语言之所以不需要给这些环节命名，是因为组织结构把它们都吸收掉了。</p>
@@ -83,6 +81,42 @@
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">我目前正在把这套框架应用到自己的一个项目——<a style="color:rgb(53,148,247);text-decoration:none;" href="https://github.com/onsager-ai/onsager"><em style="font-style:italic;">Onsager</em></a>——上，它要做的是为软件开发场景搭建一类 AI 智能体流水线。一路走下来最大的收获，并不是验证了 VSM 的完整性，而是这套模型让&quot;缺什么&quot;变得非常显眼。两个层级尤其如此——S4 和痛快通道，也正好是最常被人轻描淡写为&quot;用不到&quot;的两个——它们一旦缺席，迟早会以 §4 描述过的那些失败形态浮出水面。这件事还处在很早期，我学到的大部分东西仍然只适用于自己当前的语境，但 VSM 在诊断阶段已经足够有用，所以我想在实施细节那篇文章落地之前先把它标出来。具体的实施工作，等到能写出来再单开一篇。</p>
 <hr style="border:none;border-top:2px solid rgba(64,184,250,0.4);margin:10px 0;" />
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;"><em style="font-style:italic;">当系统的部件本身开始携带目的，我们需要的不是一种新的架构范式，而是一门被遗忘了很久的旧语言。</em></p>
+<h2 style="font-size:20px;font-weight:bold;margin:30px 0 15px;padding:0;color:rgb(64,184,250);background-color:transparent;border-bottom:4px solid rgb(64,184,250);line-height:1.5em;">参考资料</h2>
+<ol style="padding-left:0;margin:8px 0;"><li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">AI 编程智能体（AI Coding Agents）
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/ai-agents-engineering">https://marvinzhang.dev/zh/blog/ai-agents-engineering</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">Norbert Wiener
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Norbert_Wiener">https://en.wikipedia.org/wiki/Norbert_Wiener</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">W. Ross Ashby
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/W._Ross_Ashby">https://en.wikipedia.org/wiki/W._Ross_Ashby</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">可变性律（Law of Requisite Variety）
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Variety_(cybernetics)">https://en.wikipedia.org/wiki/Variety_(cybernetics)</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">一个系统的良好调节器必须是该系统的模型
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Good_regulator">https://en.wikipedia.org/wiki/Good_regulator</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">Stafford Beer
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Stafford_Beer">https://en.wikipedia.org/wiki/Stafford_Beer</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">可生存系统模型（Viable System Model）
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Viable_system_model">https://en.wikipedia.org/wiki/Viable_system_model</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">轻量级规约框架
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/introducing-leanspec">https://marvinzhang.dev/zh/blog/introducing-leanspec</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">业内对失败 AI 智能体项目的调查
+<a style="color:rgb(53,148,247);text-decoration:none;" href="https://composio.dev/blog/why-ai-agent-pilots-fail-2026-integration-roadmap">https://composio.dev/blog/why-ai-agent-pilots-fail-2026-integration-roadmap</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">2026 年更宽阔的智能体生态版图
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/agent-landscape">https://marvinzhang.dev/zh/blog/agent-landscape</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">SRE 转型实践笔记
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://cloud.google.com/blog/products/devops-sre/how-to-start-and-assess-your-sre-journey">https://cloud.google.com/blog/products/devops-sre/how-to-start-and-assess-your-sre-journey</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">当一个度量变成目标，它就不再是一个好的度量
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://en.wikipedia.org/wiki/Goodhart%27s_law">https://en.wikipedia.org/wiki/Goodhart%27s_law</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">代码没人读
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/why-your-code-reviews-are-failing-and-how-to-fix-them">https://marvinzhang.dev/zh/blog/why-your-code-reviews-are-failing-and-how-to-fix-them</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">业内多年来反复在处理的一个现象
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://jellyfish.co/blog/goodharts-law-in-software-engineering-and-how-to-avoid-gaming-your-metrics/">https://jellyfish.co/blog/goodharts-law-in-software-engineering-and-how-to-avoid-gaming-your-metrics/</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">Harness 工程
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://github.com/ai-boost/awesome-harness-engineering">https://github.com/ai-boost/awesome-harness-engineering</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">AI 的最后一公里是基础设施，不是智能
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/ai-last-mile-infrastructure">https://marvinzhang.dev/zh/blog/ai-last-mile-infrastructure</a></li>
+<li style="margin-bottom:4px;font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);">Onsager
+   <a style="color:rgb(53,148,247);text-decoration:none;" href="https://github.com/onsager-ai/onsager">https://github.com/onsager-ai/onsager</a></li>
+</ol>
 <hr style="border:none;border-top:2px solid rgba(64,184,250,0.4);margin:10px 0;" />
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">📝 <strong style="font-weight:bold;color:rgb(53,148,247);">本文同步发布于我的个人技术博客</strong> <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/vsm-cybernetics-system-organization">marvinzhang.dev</a></p>
 <p style="font-size:14px;line-height:1.8em;letter-spacing:0.02em;color:rgb(43,43,43);text-align:left;text-indent:0;margin:0;padding:8px 0;">🔗 <strong style="font-weight:bold;color:rgb(53,148,247);">完整文章链接：</strong> <a style="color:rgb(53,148,247);text-decoration:none;" href="https://marvinzhang.dev/zh/blog/vsm-cybernetics-system-organization">https://marvinzhang.dev/zh/blog/vsm-cybernetics-system-organization</a></p>


### PR DESCRIPTION
## Summary

Two improvements to the `pnpm wechat` pipeline.

### 1. Strip all MDX/JSX comments, not just `{/* truncate */}`

The script previously dropped only the truncate marker. Any other JSX comment — per-file headers like `{/* 中文译稿，逐节翻译... */}`, figure-placeholder TODOs that surface during iteration, etc. — survived into the WeChat markdown and rendered HTML as literal `{/* ... */}` text, visible to readers after copy-paste into 公众号助手. The regex now matches every `{/* ... */}` block.

### 2. Append a References section before the footer

WeChat 公众号 renders inline `<a>` links inconsistently and strips most external links for unverified accounts, so readers often can't follow citations. After URL absolutisation, the script now walks every inline link, dedupes by URL, and appends:

```
## 参考资料   (zh)
## References (en)
```

with a numbered list where the link label sits on one line and the full URL on the next — readable and copy-able regardless of whether the rendered `<a>` survives the WeChat editor.

Refinements:

- **Label cleanup**: strips markdown emphasis (`*italic*`, `**bold**`, backticks) from the label so reference entries read as plain prose instead of raw markdown. E.g. `[*Onsager*](...)` becomes `Onsager` in the reference list.
- **URL regex fix**: the link-extraction pattern now allows one level of balanced parens inside URLs, so Wikipedia-style URLs like `https://en.wikipedia.org/wiki/Variety_(cybernetics)` keep their closing paren rather than getting truncated at the first inner `)`.

Tested on the VSM × Cybernetics article — 17 unique references collected (5 internal cross-refs, 7 Wikipedia entries, 4 industry sources, 1 Onsager). The regenerated `static/wechat/vsm-cybernetics-system-organization.html` is included in the PR.

## Test plan

- [x] Run `pnpm wechat vsm-cybernetics-system-organization --zh --force` — references section appears with 17 deduped entries
- [x] Wikipedia URL with `(cybernetics)` preserved intact
- [x] `*Onsager*` and `*当一个度量变成目标...*` labels no longer carry markdown delimiters
- [x] No `{/* ... */}` strings remain in either the markdown or the HTML output
- [ ] Sanity-check a Mermaid-bearing article (e.g. `pnpm wechat agent-landscape --zh --force`) to confirm the existing flow isn't disturbed

https://claude.ai/code/session_01Hfg1TkUAy4KBRski4Vux9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hfg1TkUAy4KBRski4Vux9a)_