### PR TITLE
Drop corner brackets from the ZH article title

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-blog/2026-06-25-industrialization-of-intelligence.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/2026-06-25-industrialization-of-intelligence.mdx
@@ -1,6 +1,6 @@
 ---
 slug: industrialization-of-intelligence
-title: "从作坊到工厂：我在 AWS 峰会看到的「智力工业化」"
+title: "从作坊到工厂：我在 AWS 峰会看到的智力工业化"
 authors: ["marvin"]
 tags: ["ai", "agents", "data-infrastructure", "data-architecture", "architecture", "systems-design", "enterprise"]
 date: 2026-06-25


### PR DESCRIPTION
Removes the 「」 from the Chinese title of the industrialization-of-intelligence post:

- Before: 从作坊到工厂：我在 AWS 峰会看到的「智力工业化」
- After: 从作坊到工厂：我在 AWS 峰会看到的智力工业化

Cleaner, and matches the bracket-free English title. Body content unchanged (the WeChat HTML/MD don't embed the title, so no regeneration needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwFTowsem6N3R35h95vK1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwFTowsem6N3R35h95vK1c)_