### PR TITLE
Codify writing-process learnings from the coordination-tax article into skills

### DIFF
--- a/.agents/skills/articles/blog-analytical/SKILL.md
+++ b/.agents/skills/articles/blog-analytical/SKILL.md
@@ -58,7 +58,7 @@ Deliverables:
 - Unique value proposition identified
 - Target complexity level defined
 
-### Stage 2: Outline (1 interaction)
+### Stage 2: Outline (1 interaction) — HARD ALIGNMENT GATE
 
 Generate structural blueprint:
 - Introduction (300-500 words): Hook, context, value proposition, roadmap
@@ -67,9 +67,39 @@ Generate structural blueprint:
 
 Deliverables: `drafts/{YYYY-MM-DD-slug}/outline.md`
 
+**Do not start Stage 3 until the author approves the outline AND a hook sample.**
+Present both inline in chat: the outline plus the actual opening paragraphs
+drafted in full. The hook is where voice problems show first — a wrong hook
+approved late costs a full rewrite (learned 2026-07: a complete draft was
+rejected for hook/voice/balance issues that one alignment round would have
+caught). Title is part of this gate: it must not presuppose knowledge of a
+book, paper, or niche reference — the body may explain 《人月神话》, the
+title may not depend on it.
+
 ### Stage 3: Writing (3-6 interactions)
 
 **Write ONE section per interaction** directly to `blog/YYYY-MM-DD-slug.mdx` (with `unlisted: true`).
+
+**Chinese-first for zh-primary articles.** When the main readership is the
+公众号 audience, draft the ZH version natively in the author's voice
+(`foundation/writing-style` → zh-voice red lines), then *restate* — never
+sentence-translate — the EN version from the final ZH. Translation direction
+EN→ZH produces 翻译腔 that survives editing; drafting direction must match
+the primary audience. Record which locale is authoritative in an MDX comment.
+
+**Figures are a default deliverable, not an extra.** Deep articles ship with
+3-6 static figures in the house style (860px canvas, semantic palette,
+bilingual variants), generated from HTML sources in `drafts/{slug}/figures/`
+and rendered to `static/img/blog/{slug}/`. Reference workflow: the
+stack-selection and coordination-tax articles' `figures/gen_figures.py` +
+`render.mjs`. An interactive widget complements figures; it does not replace
+them (exports like WeChat need static images).
+
+**Notation for general readers.** Introduce symbols (λ, σ, κ, …) once with
+plain-language aliases, then keep the alias and symbol riding together at key
+mentions ("对齐成本 κ", "queueing cost σ"). Bare symbols belong only in
+formulas and parameter lists. Add a one-line reader note after the
+definitions ("记不住字母没关系，跟着中文走就行").
 
 Section checklist:
 - [ ] Appropriate word count (600-1000 for main sections)

--- a/.agents/skills/foundation/chat-driven/SKILL.md
+++ b/.agents/skills/foundation/chat-driven/SKILL.md
@@ -107,6 +107,24 @@ Make it easy for the author to give direction without precision editing:
 I'll start with Section 1: Introduction. Ready?
 ```
 
+## Alignment Gates (learned 2026-07)
+
+A complete-looking task brief is NOT a license to write the whole article
+autonomously — even when the brief arrives as a detailed prompt with every
+stage specified. The most expensive failure mode is a polished full draft
+built on an unaligned foundation: hook style, voice, content balance, and
+title were all rejected in one review, forcing a ground-up rewrite that one
+pre-writing exchange would have prevented.
+
+Mandatory stops, each a short inline-chat exchange:
+1. **Before writing**: outline + fully-drafted hook sample + title → author
+   approves or adjusts. Offer concrete options (AskUserQuestion works well
+   for direction choices: hook style, content balance, drafting language,
+   pacing).
+2. **After each author feedback round**: restate the diagnosis in your own
+   words before fixing, so a misread critique doesn't drive another wrong
+   round.
+
 ## Adaptive Question Depth
 
 Match the question style to the answer style:

--- a/.agents/skills/foundation/quality/SKILL.md
+++ b/.agents/skills/foundation/quality/SKILL.md
@@ -35,6 +35,27 @@ Validation gates and checklists for marvinzhang.dev articles.
 - [ ] Code blocks ≤10 lines
 - [ ] All diagrams theme-aware (explicit colors)
 
+## Verification Discipline
+
+Hard rules, each learned from a real incident (2026-07):
+
+1. **The exit code is the only pass signal.** A generated page or artifact
+   existing on disk does NOT mean the build passed — Docusaurus emits pages
+   before some failures, and a stale `build/` from a previous run looks
+   identical to a fresh one. Capture and check `$?` (or `echo "exit: $?"`)
+   on every `pnpm build`; never infer success from `ls`.
+2. **Re-verify after every edit, not just the big ones.** A one-line
+   frontmatter change broke a production deploy after all "significant"
+   changes had been verified. If a file changed since the last green build,
+   the last green build proves nothing.
+3. **YAML frontmatter quoting:** inside a double-quoted `title:`, inner
+   quotation marks MUST be CJK curly quotes（""）— an ASCII `"` terminates
+   the YAML string early and fails the build (locally *and* on Vercel).
+   Sanity check: the title line contains exactly two ASCII double quotes.
+4. **Push only what a full local build has verified.** CI is the backstop,
+   not the first tester; a red Vercel deploy on a published article is a
+   user-visible outage of the preview link.
+
 ## Validation Commands
 
 ```bash

--- a/.agents/skills/foundation/writing-style/SKILL.md
+++ b/.agents/skills/foundation/writing-style/SKILL.md
@@ -97,6 +97,21 @@ Figures embed prose too — when wording changes, check and re-render figures.
 See [references/zh-voice.md](references/zh-voice.md) for the author's
 vocabulary profile and a full ❌/✅ replacement table.
 
+Two additional rules from the 2026-07 rework rounds:
+
+3. **中文标题不预设读者知识**: a title must land for someone who has never
+   heard of the referenced book/paper/theorem. 《为什么 AI Agent 团队也逃
+   不过人月神话？》 gates on knowing《人月神话》; 《…"人多了反而慢"？》
+   does not. The author's question-title tradition (「真的是万能药吗」
+   「你的团队在正确实践敏捷吗」) is the pattern to reuse. The body may
+   introduce the reference properly — the title may not depend on it.
+4. **符号随行** (symbols ride along): for general-reader articles, Greek
+   letters and math symbols never travel alone in prose. Define once with a
+   plain-language alias, then pair at key mentions ("对齐成本 κ 降了，
+   排队成本 σ 升了"); bare symbols only inside formulas and parameter
+   lists. Neither extreme survives review: all-symbols loses general
+   readers, all-aliases loses the professional register.
+
 ## References
 
 - [references/economist-principles.md](references/economist-principles.md) — Detailed style guide with wit, structure, and craft guidelines


### PR DESCRIPTION
## Summary

Follow-up to #41: encode the five author-review rounds' lessons into the writing-flow skills, so the next deep article starts where this one ended instead of relearning the same corrections.

## Changes (4 skill files)

- **`articles/blog-analytical/SKILL.md`**
  - Stage 2 is now a **hard alignment gate**: outline + fully-drafted hook sample + title must be approved inline before any full-draft writing.
  - **Chinese-first drafting** for zh-primary articles; EN is a restatement, not a translation (drafting direction follows the primary audience).
  - **Figures are a default deliverable**: 3–6 static house-style figures (860px, bilingual) per deep article, with the generator/render workflow referenced.
  - **Notation rule**: symbols introduced once with plain-language aliases, then alias + symbol ride together; bare Greek only in formulas.
- **`foundation/chat-driven/SKILL.md`** — new *Alignment Gates* section: a complete-looking task brief is not a license to write the whole article autonomously; mandatory pre-writing and post-feedback stops.
- **`foundation/writing-style/SKILL.md`** — two new red lines: titles must not presuppose knowledge of a referenced work (e.g. 《人月神话》); 符号随行 for general-reader articles.
- **`foundation/quality/SKILL.md`** — new *Verification Discipline* section: exit code is the only pass signal (artifact-exists ≠ build-passed), re-verify after every edit, CJK curly quotes inside YAML titles, full local build before any push.

Each rule cites the concrete 2026-07 incident that produced it, so the rationale survives.

## Verification

- Docs-only change (skill markdown); no build surface affected.
- Rules cross-checked against the incidents recorded in `drafts/2026-07-13-.../progress.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMeMtKNwwk6RWyB8eQdeRk)_