### PR TITLE
chore(process): bake in five retrospective improvements from the cheap-code session

### DIFF
--- a/.agents/skills/foundation/quality/SKILL.md
+++ b/.agents/skills/foundation/quality/SKILL.md
@@ -56,6 +56,27 @@ Hard rules, each learned from a real incident (2026-07):
    not the first tester; a red Vercel deploy on a published article is a
    user-visible outage of the preview link.
 
+## Draft Handoff Discipline
+
+Learned from the cheap-code review round (2026-07), where a dozen one-line
+Chinese naturalness edits trickled in over as many push cycles:
+
+1. **Run the zh-voice red-line pass BEFORE presenting a ZH draft as done.**
+   The checklist lives at `foundation/writing-style/references/zh-voice.md` —
+   it catches literary-metaphor translationese (承重墙／加冕／量纲／腐蚀／
+   投下阴影…), English-calqued phrasing, and "would the author say this out
+   loud to a colleague?" failures. Localization already mandates it; treat it
+   as a hard gate, not an afterthought. When handing the draft over, list the
+   lines you yourself flagged as possibly awkward so the author reviews those
+   first instead of finding them one at a time.
+2. **Batch author nits, then verify once.** Collect a round of small edits and
+   push them together rather than commit-build-push per nit — it cuts
+   round-trips and CI/preview churn. Verification Discipline rule 2 still
+   holds: run a full `pnpm build` on the batch before pushing (frontmatter and
+   MDX-syntax errors don't surface in `validate:zh-bold-source` alone). Only a
+   truly trivial single-token ZH prose swap with no MDX-special characters may
+   rely on `validate:zh-bold-source` by itself.
+
 ## Validation Commands
 
 ```bash

--- a/.agents/skills/foundation/quality/SKILL.md
+++ b/.agents/skills/foundation/quality/SKILL.md
@@ -62,8 +62,8 @@ Learned from the cheap-code review round (2026-07), where a dozen one-line
 Chinese naturalness edits trickled in over as many push cycles:
 
 1. **Run the zh-voice red-line pass BEFORE presenting a ZH draft as done.**
-   The checklist lives at `foundation/writing-style/references/zh-voice.md` —
-   it catches literary-metaphor translationese (承重墙／加冕／量纲／腐蚀／
+   The checklist lives at `../writing-style/references/zh-voice.md` (relative
+   to this skill) — it catches literary-metaphor translationese (承重墙／加冕／量纲／腐蚀／
    投下阴影…), English-calqued phrasing, and "would the author say this out
    loud to a colleague?" failures. Localization already mandates it; treat it
    as a hard gate, not an afterthought. When handing the draft over, list the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ marvinzhang.dev/
 - Manage tasks via todo list tool (one in-progress at a time)
 - Write blog content directly to final MDX paths
 - Keep explanations skimmable—share deltas, not full plans
+- Routine Vercel deploy webhooks (Building/Ready with no failure) need no reply—stay silent and keep working. Only surface CI *failures*, review comments, or merge-conflict / base-recovered notices. (Codified 2026-07 after a review round produced ~15 "routine, no action" acknowledgements.)
 
 ## Drafts Workflow
 

--- a/scripts/generate-wechat-html.js
+++ b/scripts/generate-wechat-html.js
@@ -314,6 +314,27 @@ function convertMarkdownToWeChatHTML(mdContent) {
   return `<section style="${S.body}">${html}</section>`;
 }
 
+// Defense-in-depth: catch any attribute value that emitted a raw ASCII " and
+// broke its "-delimited attribute (the 2026-07 image-alt bug, where ZH figure
+// captions like "在场" terminated alt=""). For every start tag, strip the
+// well-formed name="value" pairs and boolean attrs; a leftover " means a value
+// contained an unescaped quote. Throw loudly rather than ship invalid HTML.
+function assertWellFormedTags(html, label) {
+  const bad = [];
+  for (const tag of html.match(/<[a-zA-Z][^>]*>/g) || []) {
+    const stripped = tag
+      .replace(/\s+[a-zA-Z_:][-\w:.]*\s*=\s*"[^"]*"/g, '') // attr="value"
+      .replace(/\s+[a-zA-Z_:][-\w:.]*(?=[\s/>])/g, '');     // boolean attrs
+    if (stripped.includes('"')) bad.push(tag.slice(0, 140));
+  }
+  if (bad.length) {
+    throw new Error(
+      `[wechat] Malformed HTML in ${label}: ${bad.length} tag(s) contain an unescaped " ` +
+      `inside an attribute (a custom renderer likely skipped escaping). First offender:\n${bad[0]}`
+    );
+  }
+}
+
 function generateHTMLFile(wechatFile) {
   const content = fs.readFileSync(wechatFile.path, 'utf-8');
   // Strip frontmatter if present
@@ -341,6 +362,8 @@ ${htmlBody}
 </body>
 </html>
 `;
+
+  assertWellFormedTags(fullDoc, outputName);
 
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
   fs.writeFileSync(outputPath, fullDoc, 'utf-8');

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -22,21 +22,26 @@ if (!target || !out) {
   console.error('usage: node scripts/screenshot.mjs <url-or-file> <out.png> [width] [height] [selector]');
   process.exit(1);
 }
-const url = /^https?:\/\//.test(target) ? target : 'file://' + resolve(target);
+// Accept http(s):// and file:// URLs as-is; treat anything else as a local
+// path to wrap in file:// (don't double-prefix an existing file:// URL).
+const url = /^(https?|file):\/\//.test(target) ? target : 'file://' + resolve(target);
 
 const browser = await chromium
   .launch({ executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome', args: ['--no-sandbox'] })
   .catch(() => chromium.launch({ args: ['--no-sandbox'] }));
-const page = await browser.newPage({
-  viewport: { width: Number(width), height: Number(height) },
-  deviceScaleFactor: 2,
-});
-await page.goto(url, { waitUntil: 'networkidle' }).catch(() => page.goto(url, { waitUntil: 'load' }));
-await page.waitForTimeout(800); // font-paint safety margin
-if (selector) {
-  await page.locator(selector).screenshot({ path: resolve(out) });
-} else {
-  await page.screenshot({ path: resolve(out), fullPage: true });
+try {
+  const page = await browser.newPage({
+    viewport: { width: Number(width), height: Number(height) },
+    deviceScaleFactor: 2,
+  });
+  await page.goto(url, { waitUntil: 'networkidle' }).catch(() => page.goto(url, { waitUntil: 'load' }));
+  await page.waitForTimeout(800); // font-paint safety margin
+  if (selector) {
+    await page.locator(selector).screenshot({ path: resolve(out) });
+  } else {
+    await page.screenshot({ path: resolve(out), fullPage: true });
+  }
+  console.log('screenshot ->', out);
+} finally {
+  await browser.close(); // always clean up, even if goto/screenshot throws
 }
-await browser.close();
-console.log('screenshot ->', out);

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,0 +1,42 @@
+// Reusable one-off screenshot helper for this repo.
+//
+// Why this exists: ad-hoc Playwright scripts keep re-hitting two papercuts —
+//   (1) ERR_MODULE_NOT_FOUND when the script lives outside the project (Node
+//       can't resolve `playwright`), so ALWAYS run it from within the repo, and
+//   (2) the pinned Chromium mismatch, which needs an explicit executablePath
+//       plus --no-sandbox in this environment.
+// This wrapper bakes both fixes in. Prefer it over hand-writing a new script.
+//
+// Usage:
+//   node scripts/screenshot.mjs <url-or-file> <out.png> [width] [height] [selector]
+//
+// Examples:
+//   node scripts/screenshot.mjs static/wechat/foo.html /tmp/foo.png 390 1500
+//   node scripts/screenshot.mjs https://example.com out.png 1280 800
+//   node scripts/screenshot.mjs page.html el.png 960 1600 ".canvas"   # clip to selector
+import { chromium } from 'playwright';
+import { resolve } from 'path';
+
+const [target, out, width = '960', height = '1200', selector] = process.argv.slice(2);
+if (!target || !out) {
+  console.error('usage: node scripts/screenshot.mjs <url-or-file> <out.png> [width] [height] [selector]');
+  process.exit(1);
+}
+const url = /^https?:\/\//.test(target) ? target : 'file://' + resolve(target);
+
+const browser = await chromium
+  .launch({ executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome', args: ['--no-sandbox'] })
+  .catch(() => chromium.launch({ args: ['--no-sandbox'] }));
+const page = await browser.newPage({
+  viewport: { width: Number(width), height: Number(height) },
+  deviceScaleFactor: 2,
+});
+await page.goto(url, { waitUntil: 'networkidle' }).catch(() => page.goto(url, { waitUntil: 'load' }));
+await page.waitForTimeout(800); // font-paint safety margin
+if (selector) {
+  await page.locator(selector).screenshot({ path: resolve(out) });
+} else {
+  await page.screenshot({ path: resolve(out), fullPage: true });
+}
+await browser.close();
+console.log('screenshot ->', out);


### PR DESCRIPTION
## What this is

Codifies five process/tooling improvements surfaced by a session retro on the "Cheap Code, Scarce Attention" article, so the friction doesn't recur.

## Changes

1. **zh-voice red-line pass as a handoff gate** (`foundation/quality` skill) — run `foundation/writing-style/references/zh-voice.md` before presenting a ZH draft as done, and hand over a self-flagged list of awkward lines. Would have pre-empted most of the naturalness nits this session (招聘广告, 我把话说全了, 这些年, literary metaphors the checklist already forbids).
2. **HTML-validity guard in the WeChat generator** (`scripts/generate-wechat-html.js`) — `assertWellFormedTags` throws if any attribute value contains an unescaped ASCII `"` before writing the file. Catches the image-`alt` class of bug (the one Copilot caught) at generation time. Positive + negative tested.
3. **Batch author nits, verify once** (`foundation/quality` skill) — one verified push per review round instead of commit-build-push per nit; full `pnpm build` stays the gate for structural/frontmatter/MDX changes.
4. **Silence on routine Vercel webhooks** (`AGENTS.md`) — Building/Ready pings with no failure get no reply; only CI failures / review comments / conflict notices are surfaced.
5. **Reusable screenshot helper** (`scripts/screenshot.mjs`) — pinned Chromium `executablePath` + `--no-sandbox` + in-repo path baked in, so ad-hoc Playwright scripts stop re-hitting `ERR_MODULE_NOT_FOUND` / version drift.

## Verification

- `node scripts/generate-wechat-html.js cheap-code-scarce-attention` passes (validator green on good HTML); negative test confirms it flags a tag with an unescaped inner quote.
- `scripts/screenshot.mjs` produces a PNG against the WeChat HTML.
- Docs-only changes to `AGENTS.md` and the quality skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F277nNgyWAswxxKKL1wzY4

---
_Generated by [Claude Code](https://claude.ai/code/session_01F277nNgyWAswxxKKL1wzY4)_